### PR TITLE
Add dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Prerequisite: currently I have it up and running for Visual Studio 2017 Communit
 
 Open the `cpp11training/cpp11training.sln` solution.
 
+### Docker host
+
+If you don't want to litter your system with tools you don't trust, but you _do_ trust Docker, you can
+build and run the docker container in [docker](docker).  You may even be in luck and simply `docker pull xtofl/cpp11training`.
+
+Then, clone the repository, and start a cpp11training container.  Now you can follow the steps like in Linux.
+
+(windows users may be happy to find a `run_container.bat` script to help)
 
 ## Exercising
 

--- a/cpp11training/CMakeLists.txt
+++ b/cpp11training/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.8.0)
 include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/SetupGoogletest.cmake")
 
 set(CMAKE_CXX_STANDARD 17)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:18.04
+
+RUN apt update
+RUN apt install -y gcc-8 cmake
+RUN apt install -y vim git
+RUN apt install -y g++-8

--- a/docker/build-container.bat
+++ b/docker/build-container.bat
@@ -1,0 +1,1 @@
+docker build --tag cpp11training %~dp0

--- a/docker/run_container.bat
+++ b/docker/run_container.bat
@@ -1,0 +1,1 @@
+docker run -it -v "%~dp0:/cpp11training" cpptraining /bin/bash


### PR DESCRIPTION
Some people have trouble setting up their toolchain.  That's a pity, but while giving training, there has to be a backup.

That backup can now be: download and install docker, build the container and compile from within.

Most of the time these people are windows users (they're pampered too much :) ), so I also added a batch file to start up that container.