### PR TITLE
Fix clang-5 and clang-6 build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
             - sourceline: deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main
               key_url: https://%{app_host}/files/gpg/llvm-toolchain-trusty.asc
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
     - env: CXX=clang++-6.0 CC=clang-6.0
       addons:
         apt:
@@ -27,9 +26,7 @@ matrix:
             - g++-7 # For the standard library
             - cmake
           sources: &sources
-            - llvm-toolchain-trusty-6.0
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
     - env: CXX=clang++-5.0 CC=clang-5.0
       addons:
         apt:
@@ -38,9 +35,7 @@ matrix:
             - g++-7 # For the standard library
             - cmake
           sources: &sources
-            - llvm-toolchain-trusty-5.0
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
     - env: CXX=g++-8 CC=gcc-8
       addons:
         apt:
@@ -49,7 +44,6 @@ matrix:
             - cmake
           sources: &sources
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
     - env: CXX=g++-7 CC=gcc-7
       addons:
         apt:
@@ -58,7 +52,6 @@ matrix:
             - cmake
           sources: &sources
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
 
 script:
     - cd cpp11training


### PR DESCRIPTION
Travis build fails because of missing package.  This seems to be related
to the package sources.

This way I try to match the settings from
https://stackoverflow.com/a/56743234/6610